### PR TITLE
Add Focus Command, Help Text for Focus, Fix Focus Bug

### DIFF
--- a/src/main/java/command/action/FocusAction.java
+++ b/src/main/java/command/action/FocusAction.java
@@ -29,7 +29,7 @@ public class FocusAction extends Action{
                 tasks.indexOption = MessageOptions.INDEXED_NUM;
             }
             return builder.toString();
-        } else if(typeTask == "Deadline"){
+        } else if(typeTask.equals(Constants.DEADLINE)){
             ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
             filtered.removeIf(t-> !(t instanceof Deadline));
             StringBuilder builder = new StringBuilder();
@@ -44,7 +44,7 @@ public class FocusAction extends Action{
             }
             String result = super.act(tasks);
             return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
-        } else if(typeTask == "Todo"){
+        } else if(typeTask.equals(Constants.TODO)){
             ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
             filtered.removeIf(t-> !(t instanceof ToDo));
             StringBuilder builder = new StringBuilder();
@@ -59,7 +59,7 @@ public class FocusAction extends Action{
             }
             String result = super.act(tasks);
             return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
-        } else if(typeTask == "Event"){
+        } else if(typeTask.equals(Constants.EVENT)){
             ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
             filtered.removeIf(t-> !(t instanceof Event));
             StringBuilder builder = new StringBuilder();

--- a/src/main/java/command/action/FocusAction.java
+++ b/src/main/java/command/action/FocusAction.java
@@ -11,27 +11,30 @@ import messages.MessageOptions;
 
 import java.util.ArrayList;
 
-public class FocusAction extends Action{
+/**
+ * The type Focus action.
+ */
+public class FocusAction extends Action {
     private String typeTask;
 
     @Override
     public String act(TaskList tasks) {
         tasks.indices = new ArrayList<>();
         if (typeTask == null || typeTask.length() == 0) {
-            StringBuilder builder = new StringBuilder(Constants.NO_TASKTYPE);
+            StringBuilder builder = new StringBuilder(Constants.NO_TASK_TYPE);
             for (Task task : tasks.tasks) {
                 builder.append(task.toString()).append(Constants.WIN_NEWLINE);
                 tasks.indices.add(tasks.indexOf(task));
             }
-            if (builder.toString().equals(Constants.NO_TASKTYPE)) {
+            if (builder.toString().equals(Constants.NO_TASK_TYPE)) {
                 builder.append(Constants.NOT_FOUND);
             } else {
                 tasks.indexOption = MessageOptions.INDEXED_NUM;
             }
             return builder.toString();
-        } else if(typeTask.equals(Constants.DEADLINE)){
+        } else if (typeTask.equals(Constants.DEADLINE)) {
             ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
-            filtered.removeIf(t-> !(t instanceof Deadline));
+            filtered.removeIf(t -> !(t instanceof Deadline));
             StringBuilder builder = new StringBuilder();
             for (Task task : filtered) {
                 builder.append(task.toString()).append(Constants.WIN_NEWLINE);
@@ -44,9 +47,9 @@ public class FocusAction extends Action{
             }
             String result = super.act(tasks);
             return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
-        } else if(typeTask.equals(Constants.TODO)){
+        } else if (typeTask.equals(Constants.TODO)) {
             ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
-            filtered.removeIf(t-> !(t instanceof ToDo));
+            filtered.removeIf(t -> !(t instanceof ToDo));
             StringBuilder builder = new StringBuilder();
             for (Task task : filtered) {
                 builder.append(task.toString()).append(Constants.WIN_NEWLINE);
@@ -59,9 +62,9 @@ public class FocusAction extends Action{
             }
             String result = super.act(tasks);
             return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
-        } else if(typeTask.equals(Constants.EVENT)){
+        } else if (typeTask.equals(Constants.EVENT)) {
             ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
-            filtered.removeIf(t-> !(t instanceof Event));
+            filtered.removeIf(t -> !(t instanceof Event));
             StringBuilder builder = new StringBuilder();
             for (Task task : filtered) {
                 builder.append(task.toString()).append(Constants.WIN_NEWLINE);
@@ -74,8 +77,8 @@ public class FocusAction extends Action{
             }
             String result = super.act(tasks);
             return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
-        } else{
-            StringBuilder builder = new StringBuilder(Constants.UNIDENTIED_TYPE);
+        } else {
+            StringBuilder builder = new StringBuilder(Constants.UNIDENTIFIED_TYPE);
             return builder.toString();
         }
     }

--- a/src/main/java/command/action/FocusAction.java
+++ b/src/main/java/command/action/FocusAction.java
@@ -1,2 +1,57 @@
-package command.action;public class FocusAction {
+package command.action;
+
+import command.ParamNode;
+import constants.Constants;
+import data.TaskList;
+import jobs.Deadline;
+import jobs.Task;
+import messages.MessageOptions;
+
+import java.util.ArrayList;
+
+public class FocusAction extends Action{
+    private String typeTask;
+
+    @Override
+    public String act(TaskList tasks) {
+        tasks.indices = new ArrayList<>();
+        if (typeTask == null || typeTask.length() == 0) {
+            StringBuilder builder = new StringBuilder(Constants.NO_KEYWORD);
+            for (Task task : tasks.tasks) {
+                builder.append(task.toString()).append(Constants.WIN_NEWLINE);
+                tasks.indices.add(tasks.indexOf(task));
+            }
+            if (builder.toString().equals(Constants.NO_KEYWORD)) {
+                builder.append(Constants.NOT_FOUND);
+            } else {
+                tasks.indexOption = MessageOptions.INDEXED_NUM;
+            }
+            return builder.toString();
+        } else {
+            ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
+            filtered.removeIf(t-> !(t instanceof Deadline));
+            StringBuilder builder = new StringBuilder();
+            for (Task task : filtered) {
+                builder.append(task.toString()).append(Constants.WIN_NEWLINE);
+                tasks.indices.add(tasks.indexOf(task));
+            }
+            if (builder.toString().equals(Constants.ZERO_LENGTH_STRING)) {
+                builder.append(Constants.NOT_FOUND);
+            } else {
+                tasks.indexOption = MessageOptions.INDEXED_NUM;
+            }
+            String result = super.act(tasks);
+            return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
+        }
+    }
+
+    @Override
+    public void prepare(ParamNode args) throws Exception {
+        super.prepare(args);
+        if (args.thisData == null) {
+            typeTask = null;
+        } else {
+            typeTask = args.thisData.toFlatString();
+        }
+    }
 }

--- a/src/main/java/command/action/FocusAction.java
+++ b/src/main/java/command/action/FocusAction.java
@@ -18,12 +18,12 @@ public class FocusAction extends Action{
     public String act(TaskList tasks) {
         tasks.indices = new ArrayList<>();
         if (typeTask == null || typeTask.length() == 0) {
-            StringBuilder builder = new StringBuilder(Constants.NO_KEYWORD);
+            StringBuilder builder = new StringBuilder(Constants.NO_TYPETASK);
             for (Task task : tasks.tasks) {
                 builder.append(task.toString()).append(Constants.WIN_NEWLINE);
                 tasks.indices.add(tasks.indexOf(task));
             }
-            if (builder.toString().equals(Constants.NO_KEYWORD)) {
+            if (builder.toString().equals(Constants.NO_TYPETASK)) {
                 builder.append(Constants.NOT_FOUND);
             } else {
                 tasks.indexOption = MessageOptions.INDEXED_NUM;

--- a/src/main/java/command/action/FocusAction.java
+++ b/src/main/java/command/action/FocusAction.java
@@ -18,12 +18,12 @@ public class FocusAction extends Action{
     public String act(TaskList tasks) {
         tasks.indices = new ArrayList<>();
         if (typeTask == null || typeTask.length() == 0) {
-            StringBuilder builder = new StringBuilder(Constants.NO_TYPETASK);
+            StringBuilder builder = new StringBuilder(Constants.NO_TASKTYPE);
             for (Task task : tasks.tasks) {
                 builder.append(task.toString()).append(Constants.WIN_NEWLINE);
                 tasks.indices.add(tasks.indexOf(task));
             }
-            if (builder.toString().equals(Constants.NO_TYPETASK)) {
+            if (builder.toString().equals(Constants.NO_TASKTYPE)) {
                 builder.append(Constants.NOT_FOUND);
             } else {
                 tasks.indexOption = MessageOptions.INDEXED_NUM;

--- a/src/main/java/command/action/FocusAction.java
+++ b/src/main/java/command/action/FocusAction.java
@@ -4,7 +4,9 @@ import command.ParamNode;
 import constants.Constants;
 import data.TaskList;
 import jobs.Deadline;
+import jobs.Event;
 import jobs.Task;
+import jobs.ToDo;
 import messages.MessageOptions;
 
 import java.util.ArrayList;
@@ -27,7 +29,7 @@ public class FocusAction extends Action{
                 tasks.indexOption = MessageOptions.INDEXED_NUM;
             }
             return builder.toString();
-        } else {
+        } else if(typeTask == "Deadline"){
             ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
             filtered.removeIf(t-> !(t instanceof Deadline));
             StringBuilder builder = new StringBuilder();
@@ -42,6 +44,48 @@ public class FocusAction extends Action{
             }
             String result = super.act(tasks);
             return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
+        } else if(typeTask == "Todo"){
+            ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
+            filtered.removeIf(t-> !(t instanceof ToDo));
+            StringBuilder builder = new StringBuilder();
+            for (Task task : filtered) {
+                builder.append(task.toString()).append(Constants.WIN_NEWLINE);
+                tasks.indices.add(tasks.indexOf(task));
+            }
+            if (builder.toString().equals(Constants.ZERO_LENGTH_STRING)) {
+                builder.append(Constants.NOT_FOUND);
+            } else {
+                tasks.indexOption = MessageOptions.INDEXED_NUM;
+            }
+            String result = super.act(tasks);
+            return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
+        } else if(typeTask == "Event"){
+            ArrayList<Task> filtered = new ArrayList<>(tasks.tasks);
+            filtered.removeIf(t-> !(t instanceof Event));
+            StringBuilder builder = new StringBuilder();
+            for (Task task : filtered) {
+                builder.append(task.toString()).append(Constants.WIN_NEWLINE);
+                tasks.indices.add(tasks.indexOf(task));
+            }
+            if (builder.toString().equals(Constants.ZERO_LENGTH_STRING)) {
+                builder.append(Constants.NOT_FOUND);
+            } else {
+                tasks.indexOption = MessageOptions.INDEXED_NUM;
+            }
+            String result = super.act(tasks);
+            return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
+        } else{
+            StringBuilder builder = new StringBuilder(Constants.NO_KEYWORD);
+            for (Task task : tasks.tasks) {
+                builder.append(task.toString()).append(Constants.WIN_NEWLINE);
+                tasks.indices.add(tasks.indexOf(task));
+            }
+            if (builder.toString().equals(Constants.NO_KEYWORD)) {
+                builder.append(Constants.NOT_FOUND);
+            } else {
+                tasks.indexOption = MessageOptions.INDEXED_NUM;
+            }
+            return builder.toString();
         }
     }
 

--- a/src/main/java/command/action/FocusAction.java
+++ b/src/main/java/command/action/FocusAction.java
@@ -76,15 +76,6 @@ public class FocusAction extends Action{
             return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
         } else{
             StringBuilder builder = new StringBuilder(Constants.UNIDENTIED_TYPE);
-            for (Task task : tasks.tasks) {
-                builder.append(task.toString()).append(Constants.WIN_NEWLINE);
-                tasks.indices.add(tasks.indexOf(task));
-            }
-            if (builder.toString().equals(Constants.UNIDENTIED_TYPE)) {
-                builder.append(Constants.NOT_FOUND);
-            } else {
-                tasks.indexOption = MessageOptions.INDEXED_NUM;
-            }
             return builder.toString();
         }
     }

--- a/src/main/java/command/action/FocusAction.java
+++ b/src/main/java/command/action/FocusAction.java
@@ -1,0 +1,2 @@
+package command.action;public class FocusAction {
+}

--- a/src/main/java/command/action/FocusAction.java
+++ b/src/main/java/command/action/FocusAction.java
@@ -75,12 +75,12 @@ public class FocusAction extends Action{
             String result = super.act(tasks);
             return result.replace(Constants.TEXT_PLACEHOLDER, builder.toString());
         } else{
-            StringBuilder builder = new StringBuilder(Constants.NO_KEYWORD);
+            StringBuilder builder = new StringBuilder(Constants.UNIDENTIED_TYPE);
             for (Task task : tasks.tasks) {
                 builder.append(task.toString()).append(Constants.WIN_NEWLINE);
                 tasks.indices.add(tasks.indexOf(task));
             }
-            if (builder.toString().equals(Constants.NO_KEYWORD)) {
+            if (builder.toString().equals(Constants.UNIDENTIED_TYPE)) {
                 builder.append(Constants.NOT_FOUND);
             } else {
                 tasks.indexOption = MessageOptions.INDEXED_NUM;

--- a/src/main/java/constants/Constants.java
+++ b/src/main/java/constants/Constants.java
@@ -427,6 +427,7 @@ public class Constants {
             Map.entry(DONE, HelpText.DONE),
             Map.entry(EVENT, HelpText.EVENT),
             Map.entry(FIND, HelpText.FIND),
+            Map.entry(FOCUS, HelpText.FOCUS),
             Map.entry(HELP, HelpText.HELP),
             Map.entry(LIST, HelpText.LIST),
             Map.entry(TODO, HelpText.TODO),

--- a/src/main/java/constants/Constants.java
+++ b/src/main/java/constants/Constants.java
@@ -335,13 +335,14 @@ public class Constants {
      */
     public static final String NO_KEYWORD = "No keyword provided, listing all tasks:" + WIN_NEWLINE;
     /**
-     * The constant NO_TASKTYPE.
+     * The constant NO_TASK_TYPE.
      */
-    public static final String NO_TASKTYPE= "No task type provided, listing all tasks:" + WIN_NEWLINE;
+    public static final String NO_TASK_TYPE = "No task type provided, listing all tasks:" + WIN_NEWLINE;
     /**
-     * The constant UNIDENTIED_TYPE.
+     * The constant UNIDENTIFIED_TYPE.
      */
-    public static final String UNIDENTIED_TYPE= "Unidentified task type! Please provide the correct task type." + WIN_NEWLINE;
+    public static final String UNIDENTIFIED_TYPE = "Unidentified task type! Please provide the correct task type."
+            + WIN_NEWLINE;
     /**
      * The constant LIST_HEAD.
      */

--- a/src/main/java/constants/Constants.java
+++ b/src/main/java/constants/Constants.java
@@ -317,6 +317,10 @@ public class Constants {
      */
     public static final String NO_KEYWORD = "No keyword provided, listing all tasks:" + WIN_NEWLINE;
     /**
+     * The constant NO_TYPETASK.
+     */
+    public static final String NO_TYPETASK= "No task type provided, listing all tasks:" + WIN_NEWLINE;
+    /**
      * The constant LIST_HEAD.
      */
     public static final String LIST_HEAD = "Here is the list of tasks:" + WIN_NEWLINE;

--- a/src/main/java/constants/Constants.java
+++ b/src/main/java/constants/Constants.java
@@ -323,7 +323,7 @@ public class Constants {
     /**
      * The constant UNIDENTIED_TYPE.
      */
-    public static final String UNIDENTIED_TYPE= "Unidentified task type provided, listing all tasks:" + WIN_NEWLINE;
+    public static final String UNIDENTIED_TYPE= "Unidentified task type! Please provide the correct task type." + WIN_NEWLINE;
     /**
      * The constant LIST_HEAD.
      */

--- a/src/main/java/constants/Constants.java
+++ b/src/main/java/constants/Constants.java
@@ -1,24 +1,7 @@
 package constants;
 
 
-import command.action.Action;
-import command.action.ByeAction;
-import command.action.ClearAction;
-import command.action.DeadlineAction;
-import command.action.DeleteAction;
-import command.action.DoneAction;
-import command.action.EventAction;
-import command.action.FancyAction;
-import command.action.FindAction;
-import command.action.HelpAction;
-import command.action.ListAction;
-import command.action.McAction;
-import command.action.NextAction;
-import command.action.PlainAction;
-import command.action.PrevAction;
-import command.action.TodoAction;
-import command.action.UndoneAction;
-import command.action.UnknownAction;
+import command.action.*;
 
 import java.util.Map;
 
@@ -210,6 +193,10 @@ public class Constants {
      * The constant FIND.
      */
     public static final String FIND = "find";
+    /**
+     * The constant FOCUS.
+     */
+    public static final String FOCUS = "focus";
     /**
      * The constant HELP.
      */
@@ -412,6 +399,7 @@ public class Constants {
             Map.entry(FIND, new FindAction()),
             Map.entry(HELP, new HelpAction()),
             Map.entry(LIST, new ListAction()),
+            Map.entry(FOCUS, new FocusAction()),
             Map.entry(MC, new McAction()),
             Map.entry(TODO, new TodoAction()),
             Map.entry(UNDONE, new UndoneAction()),
@@ -453,6 +441,7 @@ public class Constants {
     public static final Map<String, String[]> optionalParamMap = Map.ofEntries(
             Map.entry(MC, new String[]{"p", "d"}),
             Map.entry(LIST, new String[]{"date", "asc", "desc", "spec","mod"}),
+            Map.entry(FOCUS, new String[]{"Deadline", "Todo", "Event"}),
             Map.entry(PREV, new String[]{"i", "s", "a"}),
             Map.entry(NEXT, new String[]{"i", "s", "a"}));
     /**
@@ -467,6 +456,8 @@ public class Constants {
                     + WIN_NEWLINE + TEXT_PLACEHOLDER),
             Map.entry(EVENT, ADDED + CHANGED),
             Map.entry(FIND, "Tasks with the specified keyword are:"
+                    + WIN_NEWLINE + TEXT_PLACEHOLDER),
+            Map.entry(FOCUS, "Tasks with the specified task type are:"
                     + WIN_NEWLINE + TEXT_PLACEHOLDER),
             Map.entry(HELP, TEXT_PLACEHOLDER),
             Map.entry(LIST, TEXT_PLACEHOLDER),

--- a/src/main/java/constants/Constants.java
+++ b/src/main/java/constants/Constants.java
@@ -1,7 +1,25 @@
 package constants;
 
 
-import command.action.*;
+import command.action.Action;
+import command.action.ByeAction;
+import command.action.ClearAction;
+import command.action.DeadlineAction;
+import command.action.DeleteAction;
+import command.action.DoneAction;
+import command.action.EventAction;
+import command.action.FancyAction;
+import command.action.FindAction;
+import command.action.FocusAction;
+import command.action.HelpAction;
+import command.action.ListAction;
+import command.action.McAction;
+import command.action.NextAction;
+import command.action.PlainAction;
+import command.action.PrevAction;
+import command.action.TodoAction;
+import command.action.UndoneAction;
+import command.action.UnknownAction;
 
 import java.util.Map;
 

--- a/src/main/java/constants/Constants.java
+++ b/src/main/java/constants/Constants.java
@@ -317,9 +317,13 @@ public class Constants {
      */
     public static final String NO_KEYWORD = "No keyword provided, listing all tasks:" + WIN_NEWLINE;
     /**
-     * The constant NO_TYPETASK.
+     * The constant NO_TASKTYPE.
      */
-    public static final String NO_TYPETASK= "No task type provided, listing all tasks:" + WIN_NEWLINE;
+    public static final String NO_TASKTYPE= "No task type provided, listing all tasks:" + WIN_NEWLINE;
+    /**
+     * The constant UNIDENTIED_TYPE.
+     */
+    public static final String UNIDENTIED_TYPE= "Unidentified task type provided, listing all tasks:" + WIN_NEWLINE;
     /**
      * The constant LIST_HEAD.
      */

--- a/src/main/java/constants/Constants.java
+++ b/src/main/java/constants/Constants.java
@@ -441,7 +441,7 @@ public class Constants {
     public static final Map<String, String[]> optionalParamMap = Map.ofEntries(
             Map.entry(MC, new String[]{"p", "d"}),
             Map.entry(LIST, new String[]{"date", "asc", "desc", "spec","mod"}),
-            Map.entry(FOCUS, new String[]{"Deadline", "Todo", "Event"}),
+            Map.entry(FOCUS, new String[]{DEADLINE, TODO, EVENT}),
             Map.entry(PREV, new String[]{"i", "s", "a"}),
             Map.entry(NEXT, new String[]{"i", "s", "a"}));
     /**

--- a/src/main/java/constants/HelpText.java
+++ b/src/main/java/constants/HelpText.java
@@ -129,12 +129,12 @@ public enum HelpText {
             "focus",
             "Print a list of all added tasks/modules based on task type",
             new String[]{
-                    "focus",
-                    "focus [deadline / todo / event]",
+                "focus",
+                "focus [deadline / todo / event]"
             },
             new String[]{
-                    "1. \"focus\" >> list all tasks",
-                    "2. \"focus deadline\" >> list all deadline tasks",
+                "1. \"focus\" >> list all tasks",
+                "2. \"focus deadline\" >> list all deadline tasks"
             }),
     /**
      * The Todo.

--- a/src/main/java/constants/HelpText.java
+++ b/src/main/java/constants/HelpText.java
@@ -123,6 +123,20 @@ public enum HelpText {
                 "4. \"list mod\" >> list all the modules"
             }),
     /**
+     * The Focus.
+     */
+    FOCUS(
+            "focus",
+            "Print a list of all added tasks/modules based on task type",
+            new String[]{
+                    "focus",
+                    "focus [deadline / todo / event]",
+            },
+            new String[]{
+                    "1. \"focus\" >> list all tasks",
+                    "2. \"focus deadline\" >> list all deadline tasks",
+            }),
+    /**
      * The Todo.
      */
     TODO(


### PR DESCRIPTION
Focus command: make matching task type list

Focus command is case sensitive.

A case insensitive focus is more user-friendly because users cannot be
expected to remember the exact case of the keywords.

Let's,
* update the search algorithm to use case-insensitive matching
* add some sorting algorithm based on date
* make find command to be insensitive as well